### PR TITLE
chore(github): Create reusable test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,45 +5,14 @@ on:
       - master
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        uses: ./.github/actions/setup
-      - name: Check lint
-        run: yarn lint
-
-  unittests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Node and Dependencies
-        uses: ./.github/actions/setup
-      - name: Run unittests
-        run: yarn test
-      - name: Save coverage
-        uses: actions/upload-artifact@v2
-        with:
-          name: lcov.info
-          path: coverage/lcov.info
-
-  sonarcloud:
-    needs: [unittests]
-    name: SonarCloud
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Execute sonar action
-        uses: ./.github/actions/sonar_scan
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          sonar_token: ${{ secrets.SONAR_TOKEN }}
+  test:
+    name: Test
+    uses: ./.github/workflows/test.yml
+    secrets: inherit
 
   build:
-    needs: [lint, sonarcloud]
+    needs:
+      - test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,47 +6,19 @@ on:
       - develop
     types:
       - opened
+      - edited
       - synchronize
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Node and Dependencies
-        uses: ./.github/actions/setup
-      - name: Check lint
-        run: yarn lint
-
-  unittests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Node and Dependencies
-        uses: ./.github/actions/setup
-      - name: Run unittests
-        run: yarn test
-      - name: Save coverage
-        uses: actions/upload-artifact@v2
-        with:
-          name: lcov.info
-          path: coverage/lcov.info
-
-  sonarcloud:
-    needs: [unittests]
-    runs-on: ubuntu-latest
-    if: github.actor != 'dependabot[bot]'
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Execute sonar action
-        uses: ./.github/actions/sonar_scan
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          sonar_token: ${{ secrets.SONAR_TOKEN }}
+  test_pr:
+    name: Test PR
+    uses: ./.github/workflows/test.yml
+    secrets: inherit
 
   build_test:
+    name: Building
+    needs:
+      - test_pr
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+name: Test
+on:
+  workflow_call:
+
+jobs:
+  lint:
+    name: Linting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node and Dependencies
+        uses: ./.github/actions/setup
+      - name: Check lint
+        run: yarn lint
+
+  unittests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node and Dependencies
+        uses: ./.github/actions/setup
+      - name: Run unittests
+        run: yarn test
+      - name: Save coverage
+        uses: actions/upload-artifact@v2
+        with:
+          name: lcov.info
+          path: coverage/lcov.info
+
+  sonarcloud:
+    name: SonarCloud Scan
+    needs: [unittests, lint]
+    runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Execute sonar action
+        uses: ./.github/actions/sonar_scan
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          sonar_token: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
**Changes proposed in this pull request:**
This PR moves the duplicated test job steps of the PR analysis and the CI workflow into a reusable test workflow. PR and CI workflow are adjusted to call the test workflow.
