### PR TITLE
Add multiple ubuntu runner to tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,16 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./dist
-          key: build-cache-${{github.run_id}}-${{github.run_attempt}}
+          key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}
 
   integration_test:
     needs: [build]
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
         version: [12, 14, 16]
-    name: Test action with Node v${{matrix.version}}
+    runs-on: ${{ matrix.os }}
+    name: Test action with Node v${{ matrix.version }} and ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - name: Restore build cache
@@ -40,14 +41,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./dist
-          key: build-cache-${{github.run_id}}-${{github.run_attempt}}
+          key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}
       - name: Ensure cache is restored
         if: steps.build-restore.outputs.cache-hit != 'true'
         run: exit 1
       - name: Run local action with latest tags
         uses: ./
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{ secrets.GITHUB_TOKEN }}
           use-linkcheck: true
           use-mermaid: true
           use-toc: true
@@ -73,7 +74,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./dist
-          key: build-cache-${{github.run_id}}-${{github.run_attempt}}
+          key: build-cache-${{ github.run_id }}-${{ github.run_attempt }}
       - name: Ensure cache is restored
         if: steps.build-restore.outputs.cache-hit != 'true'
         run: exit 1

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -7,11 +7,13 @@ on:
 
 jobs:
   mdBook:
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
         version: [12, 14, 16]
-    name: MdBook (Node ${{matrix.version}})
+    runs-on: ${{ matrix.os }}
+    name: MdBook (Node ${{ matrix.version }} - ${{ matrix.os }})
     steps:
       - uses: actions/checkout@v2
       - name: Setup matrix node
@@ -21,17 +23,19 @@ jobs:
       - name: Download latest mdbook
         uses: ./
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Test mdBook binary
         run: mdbook --version || exit 1
 
   linkcheck:
     needs: [mdBook]
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
         version: [12, 14, 16]
-    name: Mdbook Linkcheck (Node ${{matrix.version}})
+    runs-on: ${{ matrix.os }}
+    name: Mdbook Linkcheck (Node ${{ matrix.version }} - ${{ matrix.os }})
     steps:
       - uses: actions/checkout@v2
       - name: Setup matrix node
@@ -41,18 +45,20 @@ jobs:
       - name: Download latest linkcheck
         uses: ./
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{ secrets.GITHUB_TOKEN }}
           use-linkcheck: true
       - name: Test mdbook-linkcheck binary
         run: mdbook-linkcheck --version || exit 1
 
   mermaid:
     needs: [mdBook]
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
         version: [12, 14, 16]
-    name: Mdbook Mermaid (Node ${{matrix.version}})
+    runs-on: ${{ matrix.os }}
+    name: Mdbook Mermaid (Node ${{ matrix.version }} - ${{ matrix.os }})
     steps:
       - uses: actions/checkout@v2
       - name: Setup matrix node
@@ -62,18 +68,20 @@ jobs:
       - name: Download latest mermaid
         uses: ./
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{ secrets.GITHUB_TOKEN }}
           use-mermaid: true
       - name: Test mdbook-mermaid binary
         run: mdbook-mermaid --version || exit 1
 
   toc:
     needs: [mdBook]
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
         version: [12, 14, 16]
-    name: Mdbook ToC (Node ${{matrix.version}})
+    runs-on: ${{ matrix.os }}
+    name: Mdbook ToC (Node ${{ matrix.version }} - ${{ matrix.os }})
     steps:
       - uses: actions/checkout@v2
       - name: Setup matrix node
@@ -83,18 +91,20 @@ jobs:
       - name: Download latest toc
         uses: ./
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{ secrets.GITHUB_TOKEN }}
           use-toc: true
       - name: Test mdbook-toc binary
         run: mdbook-toc --version || exit 1
 
   open_on_gh:
     needs: [mdBook]
-    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
         version: [12, 14, 16]
-    name: Mdbook OpenOnGh (Node ${{matrix.version}})
+    runs-on: ${{ matrix.os }}
+    name: Mdbook OpenOnGh (Node ${{ matrix.version }} - ${{ matrix.os }})
     steps:
       - uses: actions/checkout@v2
       - name: Setup matrix node
@@ -104,7 +114,7 @@ jobs:
       - name: Download latest open-on-gh
         uses: ./
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{ secrets.GITHUB_TOKEN }}
           use-opengh: true
       - name: Test mdbook-open-on-gh binary
         run: mdbook-open-on-gh --version || exit 1


### PR DESCRIPTION
**Changes proposed in this pull request:**
This PR adds multiple ubuntu runners to the scheduled tests that run every day. This was done to detect errors like #290 earlier e.g. due to a newly published github runner version.

**Please check...**

- [x] Files are formated with prettier
- [x] New code is covered with unittests
- [x] All unittests are passing
- [x] All commits are [semantic](https://www.conventionalcommits.org)
