### PR TITLE
Use musl build for failing gnu binaries

### DIFF
--- a/src/mdbook/plugins/OpenGh.spec.ts
+++ b/src/mdbook/plugins/OpenGh.spec.ts
@@ -15,7 +15,7 @@ describe("OpenGh", () => {
       "badboy/mdbook-open-on-gh",
       "opengh-version",
       "mdbook-open-on-gh",
-      "unknown-linux-gnu"
+      "unknown-linux-musl"
     );
   });
 });

--- a/src/mdbook/plugins/OpenGh.ts
+++ b/src/mdbook/plugins/OpenGh.ts
@@ -6,7 +6,7 @@ export class OpenGh extends MdPlugin {
       "badboy/mdbook-open-on-gh",
       "opengh-version",
       "mdbook-open-on-gh",
-      "unknown-linux-gnu"
+      "unknown-linux-musl"
     );
   }
 }

--- a/src/mdbook/plugins/Toc.spec.ts
+++ b/src/mdbook/plugins/Toc.spec.ts
@@ -13,7 +13,7 @@ describe("Toc", () => {
       "badboy/mdbook-toc",
       "toc-version",
       "mdbook-toc",
-      "unknown-linux-gnu"
+      "unknown-linux-musl"
     );
     expect(linkchecker).toBeDefined();
   });

--- a/src/mdbook/plugins/Toc.ts
+++ b/src/mdbook/plugins/Toc.ts
@@ -6,7 +6,7 @@ export class Toc extends MdPlugin {
       "badboy/mdbook-toc",
       "toc-version",
       "mdbook-toc",
-      "unknown-linux-gnu"
+      "unknown-linux-musl"
     );
   }
 }


### PR DESCRIPTION
This PR should fix the failing OpenOnGh and ToC plugin binaries that were failing due to an glibc dependency of the gnu compiled binaries. The switching to the more statically compiled musl binaries fixes this.

**Please check...**

- [x] Files are formated with prettier
- [x] New code is covered with unittests
- [x] All unittests are passing
- [x] All commits are [semantic](https://www.conventionalcommits.org)
