### PR TITLE
feat(plugin): Add support for the katex plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
           use-toc: true
           use-opengh: true
           use-admonish: true
+          use-katex: true
       - name: Test mdBook binary
         run: mdbook --version
       - name: Test mdbook-linkcheck binary
@@ -66,6 +67,8 @@ jobs:
         run: mdbook-open-on-gh --version
       - name: Test mdbook-admonish binary
         run: mdbook-admonish --version
+      - name: Test mdbook-katex binary
+        run: mdbook-katex --version
 
   release:
     needs: [integration_test]

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -141,3 +141,26 @@ jobs:
           use-admonish: true
       - name: Test mdbook-admonish binary
         run: mdbook-admonish --version || exit 1
+
+  katex:
+    needs: [mdBook]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04]
+        version: [14, 16, 18]
+    runs-on: ${{ matrix.os }}
+    name: Mdbook Katex (Node ${{ matrix.version }} - ${{ matrix.os }})
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup matrix node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.version }}
+      - name: Download latest katex
+        uses: ./
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          use-katex: true
+      - name: Test mdbook-katex binary
+        run: mdbook-katex --version || exit 1

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This action runs only on linux and is well tested on github **latest ubuntu** ru
 - [badboy/mdbook-toc](https://github.com/badboy/mdbook-toc)
 - [badboy/mdbook-open-on-gh](https://github.com/badboy/mdbook-open-on-gh)
 - [tommilligan/mdbook-admonish](https://github.com/tommilligan/mdbook-admonish)
+- [lzanini/mdbook-katex](https://github.com/lzanini/mdbook-katex)
 
 ## Fast Setup
 
@@ -41,6 +42,7 @@ jobs:
           use-toc: true
           use-opengh: true
           use-admonish: true
+          use-katex: true
       - name: Show mdbook version
         run: mdbook --version
       - name: Show linkchecker version
@@ -53,6 +55,8 @@ jobs:
         run: mdbook-open-on-gh --version
       - name: Show admonish version
         run: mdbook-admonish --version
+      - name: Show katex version
+        run: mdbook-katex --version
 ```
 
 ## Advanced Setup
@@ -83,6 +87,8 @@ jobs:
           opengh-version: "~2.0.0"
           use-admonish: true
           admonish-version: "~1.8.0"
+          use-katex: true
+          admonish-version: "~0.2.17"
       - name: Show mdbook version
         run: mdbook --version
       - name: Show linkchecker version
@@ -95,6 +101,8 @@ jobs:
         run: mdbook-open-on-gh --version
       - name: Show admonish version
         run: mdbook-admonish --version
+      - name: Show katex version
+        run: mdbook-katex --version
 ```
 
 ## Contributions

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,14 @@ inputs:
     description: admonish version that should be used
     required: false
     default: "latest"
+  use-katex:
+    description: "Use katex plugin (true / false)"
+    required: false
+    default: false
+  katex-version:
+    description: katex version that should be used
+    required: false
+    default: "latest"
 runs:
   using: "node16"
   main: "./dist/index.js"

--- a/src/mdbook/index.spec.ts
+++ b/src/mdbook/index.spec.ts
@@ -6,6 +6,7 @@ import * as mermaidModule from "./plugins/Mermaid";
 import * as admonishModule from "./plugins/Admonish";
 import * as openghModule from "./plugins/OpenGh";
 import * as tocModule from "./plugins/Toc";
+import * as katexModule from "./plugins/Katex";
 
 jest.mock("./MdBook");
 jest.mock("./plugins/Admonish");
@@ -13,6 +14,7 @@ jest.mock("./plugins/Linkcheck");
 jest.mock("./plugins/Mermaid");
 jest.mock("./plugins/OpenGh");
 jest.mock("./plugins/Toc");
+jest.mock("./plugins/Katex");
 
 describe("Should run action", () => {
   let spyGetBooleanInput: jest.SpyInstance<any>;
@@ -128,6 +130,24 @@ describe("Should run action", () => {
 
       expect(admonishConstructorSpy).toBeCalledTimes(1);
       expect(admonishSetupSpy).toBeCalledTimes(1);
+    });
+  });
+
+  describe("with katex plugin", () => {
+    beforeEach(() => {
+      spyGetBooleanInput.mockImplementation(
+        (activatedPlugin) => activatedPlugin === "use-katex"
+      );
+    });
+
+    it("should setup", async () => {
+      const katexConstructorSpy = jest.spyOn(katexModule, "Katex");
+      const katexSetupSpy = jest.spyOn(katexModule.Katex.prototype, "setup");
+
+      await run();
+
+      expect(katexConstructorSpy).toBeCalledTimes(1);
+      expect(katexSetupSpy).toBeCalledTimes(1);
     });
   });
 });

--- a/src/mdbook/index.ts
+++ b/src/mdbook/index.ts
@@ -1,6 +1,7 @@
 import { getBooleanInput } from "@actions/core";
 import { MdBook } from "./MdBook";
 import { Admonish } from "./plugins/Admonish";
+import { Katex } from "./plugins/Katex";
 import { Linkcheck } from "./plugins/Linkcheck";
 import { Mermaid } from "./plugins/Mermaid";
 import { OpenGh } from "./plugins/OpenGh";
@@ -41,5 +42,11 @@ export const run = async () => {
   if (getBooleanInput("use-admonish") === true) {
     const admonishPlugin = new Admonish();
     await admonishPlugin.setup();
+  }
+
+  // Katex - 3rd party preprocessor plugin for mdbook rendering LaTex equations to HTML at build time
+  if (getBooleanInput("use-katex") === true) {
+    const katexPlugin = new Katex();
+    await katexPlugin.setup();
   }
 };

--- a/src/mdbook/plugins/Katex.spec.ts
+++ b/src/mdbook/plugins/Katex.spec.ts
@@ -1,0 +1,20 @@
+import { Katex } from "./Katex";
+
+import * as PluginModule from "./MdPlugin";
+
+jest.mock("./MdPlugin");
+
+describe("Katex", () => {
+  it("should init class", () => {
+    const constructorSpy = jest.spyOn(PluginModule, "MdPlugin");
+    const katex = new Katex();
+
+    expect(constructorSpy).toHaveBeenCalledWith(
+      "lzanini/mdbook-katex",
+      "katex-version",
+      "mdbook-katex",
+      "unknown-linux-musl"
+    );
+    expect(katex).toBeDefined();
+  });
+});

--- a/src/mdbook/plugins/Katex.ts
+++ b/src/mdbook/plugins/Katex.ts
@@ -1,0 +1,12 @@
+import { MdPlugin } from "./MdPlugin";
+
+export class Katex extends MdPlugin {
+  constructor() {
+    super(
+      "lzanini/mdbook-katex",
+      "katex-version",
+      "mdbook-katex",
+      "unknown-linux-musl"
+    );
+  }
+}


### PR DESCRIPTION
This PR adds support for the [mdbook-katex](https://github.com/lzanini/mdbook-katex) plugin.

Close #301

**Please check...**

- [x] Files are formated with prettier
- [x] New code is covered with unittests
- [x] All unittests are passing
- [x] All commits are [semantic](https://www.conventionalcommits.org)
