### PR TITLE
Fix glibc version error for `mdbook-admonish` plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-mdbook",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Github action to setup mdbook and optional some popular plugins",
   "main": "dist/index.js",
   "scripts": {

--- a/src/mdbook/plugins/Admonish.spec.ts
+++ b/src/mdbook/plugins/Admonish.spec.ts
@@ -13,7 +13,7 @@ describe("Admonish", () => {
       "tommilligan/mdbook-admonish",
       "admonish-version",
       "mdbook-admonish",
-      "unknown-linux-gnu"
+      "unknown-linux-musl"
     );
     expect(admonish).toBeDefined();
   });

--- a/src/mdbook/plugins/Admonish.ts
+++ b/src/mdbook/plugins/Admonish.ts
@@ -6,7 +6,7 @@ export class Admonish extends MdPlugin {
       "tommilligan/mdbook-admonish",
       "admonish-version",
       "mdbook-admonish",
-      "unknown-linux-gnu"
+      "unknown-linux-musl"
     );
   }
 }


### PR DESCRIPTION
This PR moves from gnu to musl compiled `mdbook-admonish` binary to fix an error with an outdated GLIBC version. 

**Please check...**

- [x] Files are formated with prettier
- [x] New code is covered with unittests
- [x] All unittests are passing
- [x] All commits are [semantic](https://www.conventionalcommits.org)
