### PR TITLE
Prevent download of executable for incorrect architecture

### DIFF
--- a/src/mdbook/plugins/Admonish.spec.ts
+++ b/src/mdbook/plugins/Admonish.spec.ts
@@ -13,7 +13,7 @@ describe("Admonish", () => {
       "tommilligan/mdbook-admonish",
       "admonish-version",
       "mdbook-admonish",
-      "unknown-linux-musl",
+      "x86_64-unknown-linux-musl",
     );
     expect(admonish).toBeDefined();
   });

--- a/src/mdbook/plugins/Admonish.ts
+++ b/src/mdbook/plugins/Admonish.ts
@@ -6,7 +6,7 @@ export class Admonish extends MdPlugin {
       "tommilligan/mdbook-admonish",
       "admonish-version",
       "mdbook-admonish",
-      "unknown-linux-musl",
+      "x86_64-unknown-linux-musl",
     );
   }
 }

--- a/src/mdbook/plugins/Katex.spec.ts
+++ b/src/mdbook/plugins/Katex.spec.ts
@@ -13,7 +13,7 @@ describe("Katex", () => {
       "lzanini/mdbook-katex",
       "katex-version",
       "mdbook-katex",
-      "unknown-linux-musl",
+      "x86_64-unknown-linux-musl",
     );
     expect(katex).toBeDefined();
   });

--- a/src/mdbook/plugins/Katex.ts
+++ b/src/mdbook/plugins/Katex.ts
@@ -6,7 +6,7 @@ export class Katex extends MdPlugin {
       "lzanini/mdbook-katex",
       "katex-version",
       "mdbook-katex",
-      "unknown-linux-musl",
+      "x86_64-unknown-linux-musl",
     );
   }
 }

--- a/src/mdbook/plugins/OpenGh.spec.ts
+++ b/src/mdbook/plugins/OpenGh.spec.ts
@@ -15,7 +15,7 @@ describe("OpenGh", () => {
       "badboy/mdbook-open-on-gh",
       "opengh-version",
       "mdbook-open-on-gh",
-      "unknown-linux-musl",
+      "x86_64-unknown-linux-musl",
     );
   });
 });

--- a/src/mdbook/plugins/OpenGh.ts
+++ b/src/mdbook/plugins/OpenGh.ts
@@ -6,7 +6,7 @@ export class OpenGh extends MdPlugin {
       "badboy/mdbook-open-on-gh",
       "opengh-version",
       "mdbook-open-on-gh",
-      "unknown-linux-musl",
+      "x86_64-unknown-linux-musl",
     );
   }
 }

--- a/src/mdbook/plugins/Toc.spec.ts
+++ b/src/mdbook/plugins/Toc.spec.ts
@@ -13,7 +13,7 @@ describe("Toc", () => {
       "badboy/mdbook-toc",
       "toc-version",
       "mdbook-toc",
-      "unknown-linux-musl",
+      "x86_64-unknown-linux-musl",
     );
     expect(linkchecker).toBeDefined();
   });

--- a/src/mdbook/plugins/Toc.ts
+++ b/src/mdbook/plugins/Toc.ts
@@ -6,7 +6,7 @@ export class Toc extends MdPlugin {
       "badboy/mdbook-toc",
       "toc-version",
       "mdbook-toc",
-      "unknown-linux-musl",
+      "x86_64-unknown-linux-musl",
     );
   }
 }


### PR DESCRIPTION
**Changes proposed in this pull request:**
The release assets to download were only checked for `unknown-linux-musl` but didn't specify the processor architecture. Therefore, the wrong executables were downloaded if a plugin offered `unknown-linux-musl` for multiple arch types. This is now fixed.

**Please check...**

- [x] Files are formated with prettier
- [x] New code is covered with unittests
- [x] All unittests are passing
- [x] All commits are [semantic](https://www.conventionalcommits.org)
