### PR TITLE
chore(ci): Remove deprecated ubuntu-20.04 from test runs

### DIFF
--- a/.github/actions/sonar_scan/action.yml
+++ b/.github/actions/sonar_scan/action.yml
@@ -1,3 +1,4 @@
+---
 name: Sonarcloud
 author: Jontze
 description: This action executes the sonarcloud scan
@@ -17,7 +18,7 @@ runs:
         name: lcov.info
         path: coverage/
     - name: SonarCloud Scan
-      uses: SonarSource/sonarcloud-github-action@master
+      uses: SonarSource/sonarqube-scan-action@v5.1.0
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         SONAR_TOKEN: ${{ inputs.sonar_token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+---
 name: CI
 on:
   push:
@@ -30,7 +31,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         version: [18, 20]
     runs-on: ${{ matrix.os }}
     name: Test action with Node v${{ matrix.version }} and ${{ matrix.os }}

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         version: [18, 20]
     runs-on: ${{ matrix.os }}
     name: MdBook (Node ${{ matrix.version }} - ${{ matrix.os }})
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         version: [18, 20]
     runs-on: ${{ matrix.os }}
     name: Mdbook Linkcheck (Node ${{ matrix.version }} - ${{ matrix.os }})
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         version: [18, 20]
     runs-on: ${{ matrix.os }}
     name: Mdbook Mermaid (Node ${{ matrix.version }} - ${{ matrix.os }})
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         version: [18, 20]
     runs-on: ${{ matrix.os }}
     name: Mdbook ToC (Node ${{ matrix.version }} - ${{ matrix.os }})
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         version: [18, 20]
     runs-on: ${{ matrix.os }}
     name: Mdbook OpenOnGh (Node ${{ matrix.version }} - ${{ matrix.os }})
@@ -124,7 +124,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         version: [18, 20]
     runs-on: ${{ matrix.os }}
     name: Mdbook Admonish (Node ${{ matrix.version }} - ${{ matrix.os }})
@@ -147,7 +147,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         version: [18, 20]
     runs-on: ${{ matrix.os }}
     name: Mdbook Katex (Node ${{ matrix.version }} - ${{ matrix.os }})


### PR DESCRIPTION
This was removed as GitHub has started the brownout and deprecation of the 20.04 ubuntu runner.

