### PR TITLE
chore(dev-deps): Update SonarCloud scan action version to v5.3.1

### DIFF
--- a/.github/actions/sonar_scan/action.yml
+++ b/.github/actions/sonar_scan/action.yml
@@ -18,7 +18,7 @@ runs:
         name: lcov.info
         path: coverage/
     - name: SonarCloud Scan
-      uses: SonarSource/sonarqube-scan-action@v5.1.0
+      uses: SonarSource/sonarqube-scan-action@v5.3.1
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
         SONAR_TOKEN: ${{ inputs.sonar_token }}


### PR DESCRIPTION
This PR bumps the sonar action to the current latest version v5.3.1
